### PR TITLE
refactor: change NDTiff reader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
     { email = "douglas.shepherd@asu.edu", name = "Douglas Shepherd" },
 ]
 dynamic = ["version"]
-dependencies = ["numpy", "tifffile", "zarr", "numba", "ndstorage",
+dependencies = ["numpy", "tifffile", "zarr", "numba",
                 "numcodecs", "psfmodels", "cmap", "SimpleITK", 
                 "tqdm", "magicgui[pyqt5]", "napari", "pandas",
                 "scikit-image", "pyarrow", "tbb", "shapely",


### PR DESCRIPTION
Swapped out `ndstorage` to instead of use `tifffile` and `zarr`. Tried to get `tensorstore` to work, but the store can't be read by it.

NOTE: will need to be careful about the channel indexing, as the zarr attributes produced by `tifffile` don't have the channel_id mapping. Might need to write some extra information to disk to ensure correct loading. 