### PR TITLE
feat: make baysor_path access pattern same as other class properties

### DIFF
--- a/src/merfish3danalysis/qi2labDataStore.py
+++ b/src/merfish3danalysis/qi2labDataStore.py
@@ -3029,7 +3029,7 @@ class qi2labDataStore:
         julia_threading = "JULIA_NUM_THREADS="+str(20)+ " "
         baysor_options = r"preview -c /home/qi2lab/Documents/github/merfish3d-analysis/qi2lab.toml"
                
-        command = julia_threading + str(self.baysor_path) + " " + baysor_options + " " +\
+        command = julia_threading + str(self._baysor_path) + " " + baysor_options + " " +\
             str(baysor_input_path) + " -o " + str(baysor_output_path)
                     
         try:


### PR DESCRIPTION
Change baysor_path to private within run_baysor and make sure it is only set using class property variables