### PR TITLE
fix: deal with issues regarding pylibraft and cuVS migration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Activate the environment and install the GPU dependencies.
 
 ```
 mamba activate wf-merfish
-mamba install -c conda-forge -c nvidia -c pytorch -c rapidsai cupy cucim pylibraft cudadecon cuda-version=12.5 cudnn cutensor nccl onnx onnxruntime pytorch torchvision 'pytorch=*=*cuda*'
+mamba install -c conda-forge -c nvidia -c pytorch -c rapidsai cupy cucim cudadecon cuda-version=12.5 cudnn cutensor nccl onnx onnxruntime pytorch torchvision 'pytorch=*=*cuda*'
 ```
 
 Finally, repository using ```git clone https://github.com/QI2lab/wf-merfish``` and then install using `pip install .` or for interactive editing use `pip install -e .`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Activate the environment and install the GPU dependencies.
 
 ```
 mamba activate wf-merfish
-mamba install -c conda-forge -c nvidia -c pytorch -c rapidsai cupy cucim=24.08 cudadecon cuda-version=12.5 cudnn cutensor nccl onnx onnxruntime pytorch torchvision 'pytorch=*=*cuda*'
+mamba install -c conda-forge -c nvidia -c pytorch -c rapidsai cupy cucim=24.08 pylibraft=24.08 raft-dask=24.08 cudadecon "cuda-version>=12.0,<=12.5" cudnn cutensor nccl onnx onnxruntime pytorch torchvision 'pytorch=*=*cuda*'
 ```
 
 Finally, repository using ```git clone https://github.com/QI2lab/wf-merfish``` and then install using `pip install .` or for interactive editing use `pip install -e .`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Activate the environment and install the GPU dependencies.
 
 ```
 mamba activate wf-merfish
-mamba install -c conda-forge -c nvidia -c pytorch -c rapidsai cupy cucim cudadecon cuda-version=12.5 cudnn cutensor nccl onnx onnxruntime pytorch torchvision 'pytorch=*=*cuda*'
+mamba install -c conda-forge -c nvidia -c pytorch -c rapidsai cupy cucim=24.08 cudadecon cuda-version=12.5 cudnn cutensor nccl onnx onnxruntime pytorch torchvision 'pytorch=*=*cuda*'
 ```
 
 Finally, repository using ```git clone https://github.com/QI2lab/wf-merfish``` and then install using `pip install .` or for interactive editing use `pip install -e .`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ authors = [
 dynamic = ["version"]
 dependencies = ["numpy", "tifffile", "zarr", "numba",
                 "numcodecs", "psfmodels", "cmap", "SimpleITK", 
-                "tqdm", "pandas", "ndstorage",
+                "tqdm", "ndstorage",
                 "scikit-image", "pyarrow", "tbb", "shapely",
-                "imbalanced-learn", "scikit-learn", "dask[array]", "rtree",
+                "imbalanced-learn", "scikit-learn", "rtree",
                 "ryomen", "tensorstore",
                 "pycudadecon @ git+https://github.com/tlambert03/pycudadecon@main",
                 "ufish @ git+https://github.com/QI2lab/U-FISH.git@main",


### PR DESCRIPTION
cuPy hasn't updated for the move of `distance` to cuVS, which we need for decoding. See https://github.com/cupy/cupy/pull/8847

On a new machine, I thought using the conda rapidasi channel pylibraft would work, but I'm getting an error that it isn't present. But I also seem to get the error with the pypi wheel. 

Will need to figure out what actually works.