### PR TITLE
View all bits in display_results method in Pixel Decoder

### DIFF
--- a/examples/bioprotean_mouse/04_pixeldecode.py
+++ b/examples/bioprotean_mouse/04_pixeldecode.py
@@ -75,5 +75,5 @@ def decode_pixels(
         datastore.save_mtx()
 
 if __name__ == "__main__":
-    root_path = Path(r"/mnt/data/bartelle/20241108_Bartelle_MouseMERFISH_LC")
+    root_path = Path(r"/data/smFISH/12062024_Bartelle24hrcryo_sample2")
     decode_pixels(root_path=root_path,run_baysor=False)

--- a/examples/bioprotean_smFISH/smFISH_decoding.py
+++ b/examples/bioprotean_smFISH/smFISH_decoding.py
@@ -1,0 +1,37 @@
+from merfish3danalysis.qi2labDataStore import qi2labDataStore
+from merfish3danalysis.PixelDecoder import PixelDecoder
+from pathlib import Path
+# import numpy as np
+
+root_path = Path(r"/data/smFISH/02202025_Bartelle_control_smFISH_TqIB")
+
+# initialize datastore
+datastore_path = root_path / Path(r"qi2labdatastore")
+datastore = qi2labDataStore(datastore_path)
+merfish_bits = datastore.num_bits
+
+# initialize decodor class
+decoder = PixelDecoder(
+    datastore=datastore, 
+    use_mask=False, 
+    merfish_bits=merfish_bits, 
+    verbose=1
+)
+
+# decode one tile
+decoder.decode_one_tile(
+    tile_idx=0,  # Specify the tile index
+    display_results=True,  # Set to True to visualize results in Napari
+    lowpass_sigma=(3, 1, 1),  # Lowpass filter sigma
+    magnitude_threshold=0.9,  # L2-norm threshold
+    minimum_pixels=3.0,  # Minimum number of pixels for a barcode
+    use_normalization=True,  # Use normalization
+    ufish_threshold=0.5  # Ufish threshold
+)
+
+# # access decoded image
+# decoded_image = decoder._decoded_image
+# print(decoded_image)
+
+# # Save barcodes
+# decoder._save_barcodes()

--- a/examples/bioprotean_smFISH/smFISH_decoding.py
+++ b/examples/bioprotean_smFISH/smFISH_decoding.py
@@ -25,7 +25,7 @@ decoder.decode_one_tile(
     lowpass_sigma=(3, 1, 1),  # Lowpass filter sigma
     magnitude_threshold=0.9,  # L2-norm threshold
     minimum_pixels=3.0,  # Minimum number of pixels for a barcode
-    use_normalization=True,  # Use normalization
+    use_normalization=False,  # Use normalization
     ufish_threshold=0.5  # Ufish threshold
 )
 

--- a/examples/bioprotean_smFISH/smFISH_decoding.py
+++ b/examples/bioprotean_smFISH/smFISH_decoding.py
@@ -15,7 +15,8 @@ decoder = PixelDecoder(
     datastore=datastore, 
     use_mask=False, 
     merfish_bits=merfish_bits, 
-    verbose=1
+    verbose=1,
+    smFISH = True
 )
 
 # decode one tile

--- a/examples/bioprotean_smFISH/smFISH_decoding.py
+++ b/examples/bioprotean_smFISH/smFISH_decoding.py
@@ -29,9 +29,5 @@ decoder.decode_one_tile(
     ufish_threshold=0.5  # Ufish threshold
 )
 
-# # access decoded image
-# decoded_image = decoder._decoded_image
-# print(decoded_image)
-
 # # Save barcodes
 # decoder._save_barcodes()

--- a/examples/bioprotean_smFISH/smFISH_spot_detection.py
+++ b/examples/bioprotean_smFISH/smFISH_spot_detection.py
@@ -1,0 +1,75 @@
+from merfish3danalysis.qi2labDataStore import qi2labDataStore
+from pathlib import Path
+from typing import Union, Optional, Sequence, Collection
+import pandas as pd
+
+root_path = Path(r"/data/smFISH/02202025_Bartelle_control_smFISH_TqIB")
+
+# Initialize qi2labDataStore.
+class qi2labDataStore:
+    def __init__(self, datastore_path: Union[str, Path]):
+        self._datastore_path = Path(datastore_path)
+        self._ufish_localizations_root_path = self._datastore_path / Path(r"ufish_localizations")
+        # print(self._ufish_localizations_root_path)
+
+    def read_ufish_localizations(self, tile_id, bit_id):
+        # this method reads the Parquet file located at the constructed path (tile0000/bit001.parquet) and returns its contents as a pandas DataFrame
+        current_ufish_localizations_path = (
+            self._ufish_localizations_root_path
+            / Path(tile_id)
+            / Path(bit_id + ".parquet")
+        )
+        # if not current_ufish_localizations_path.exists():
+        #     print("U-FISH localizations not found.")
+        #  print(f"Attempting to read file: {current_ufish_localizations_path}")
+        return pd.read_parquet(current_ufish_localizations_path)
+
+datastore_path = root_path / Path(r"qi2labdatastore")
+datastore = qi2labDataStore(datastore_path)
+# The __init__ method is automatically called when you create an instance of a class, as in the above line.
+# You do not need to call it explicitly
+
+# you need to call a method of the class or it will not be executed
+ufish_localizations_df = datastore.read_ufish_localizations("tile0000", "bit001")
+# print(ufish_localizations_df)
+
+# Output:
+#        z     y     x  sum_prob_pixels  sum_decon_pixels  tile_idx  bit_idx  tile_z_px  tile_y_px  tile_x_px
+# 0      0     9  1138        33.477734              6646         0        1          0          9       1138
+# 1      0   236   563        17.889059             23476         0        1          0        236        563
+# 2      0   295   123        43.437790             11803         0        1          0        295        123
+# 3      0   355   307        41.473850            398292         0        1          0        355        307
+# 4      0   362  1336        58.301956            355961         0        1          0        362       1336
+# ...   ..   ...   ...              ...               ...       ...      ...        ...        ...        ...
+# 9009  49  1942  1100        19.608427              2911         0        1         49       1942       1100
+# 9010  49  1986  1986        20.223333              2028         0        1         49       1986       1986
+# 9011  49  1999    74        21.493113              2139         0        1         49       1999         74
+# 9012  49  2014    86        15.593759              1597         0        1         49       2014         86
+# 9013  49  2018  1375        25.273598              5003         0        1         49       2018       1375
+
+# [9014 rows x 10 columns]
+
+
+# Set the threshold for the ufish probabilities
+# threshold = 5
+
+# grab the ufish localizations
+ufish_probabilities = ufish_localizations_df.loc[:, "sum_prob_pixels"]
+# set everything <5 = 0
+thresholded_probabilities = []
+for prob in ufish_probabilities:
+    if prob < 5:
+        thresholded_probabilities.append(0)
+    else:
+        thresholded_probabilities.append(prob)
+# print(thresholded_probabilities)
+# Create a new column with thresholded values
+ufish_localizations_df["thresholded_probabilities"] = thresholded_probabilities
+
+
+# Save the updated DataFrame back to a new Parquet file
+output_path = datastore_path / "ufish_localizations_thresholded" / "tile0000" / "bit001_thresholded.parquet"
+output_path.parent.mkdir(parents=True, exist_ok=True)  # Create directories if they don't exist
+ufish_localizations_df.to_parquet(output_path)
+
+print(f"Thresholded probabilities saved to {output_path}")

--- a/examples/bioprotean_smFISH/smFISH_spot_detection.py
+++ b/examples/bioprotean_smFISH/smFISH_spot_detection.py
@@ -1,70 +1,52 @@
 from merfish3danalysis.qi2labDataStore import qi2labDataStore
 from pathlib import Path
-from typing import Union, Optional, Sequence, Collection
 import pandas as pd
-from itertools import product
 
 root_path = Path(r"/data/smFISH/02202025_Bartelle_control_smFISH_TqIB")
 
-# Initialize qi2labDataStore.
-class qi2labDataStore:
-    def __init__(self, datastore_path: Union[str, Path]):
-        self._datastore_path = Path(datastore_path)
-        self._ufish_localizations_root_path = self._datastore_path / Path(r"ufish_localizations")
-        # print(self._ufish_localizations_root_path)
+class smFISH_spotdetection:
+    def __init__(self, datastore, threshold=5):
+        self.datastore = datastore
+        self.threshold = threshold
 
     def read_ufish_localizations(self, tile_id, bit_id):
-        # this method reads the Parquet file located at the constructed path (tile0000/bit001.parquet) and returns its contents as a pandas DataFrame
+        self._ufish_localizations_root_path = self.datastore._ufish_localizations_root_path
         current_ufish_localizations_path = (
             self._ufish_localizations_root_path
             / Path(tile_id)
             / Path(bit_id + ".parquet")
         )
-        # if not current_ufish_localizations_path.exists():
-        #     print("U-FISH localizations not found.")
-        #  print(f"Attempting to read file: {current_ufish_localizations_path}")
+        if not current_ufish_localizations_path.exists():
+            raise FileNotFoundError(f"File {current_ufish_localizations_path} does not exist.")
         return pd.read_parquet(current_ufish_localizations_path)
-    
+
     def get_tile_ids(self):
-        # Retrieve tile IDs from the directory structure
-        return sorted([p.name for p in self._ufish_localizations_root_path.iterdir() if p.is_dir()], key=lambda x: int(x.replace("tile", "")))
+        if not self.datastore._ufish_localizations_root_path.exists():
+            raise FileNotFoundError(f"Directory {self.datastore._ufish_localizations_root_path} does not exist.")
+        return sorted([p.name for p in self.datastore._ufish_localizations_root_path.iterdir() if p.is_dir()], key=lambda x: int(x.replace("tile", "")))
 
     def get_bit_ids(self, tile_id):
-        # Retrieve bit IDs from the directory structure of a specific tile
-        tile_path = self._ufish_localizations_root_path / Path(tile_id)
+        tile_path = self.datastore._ufish_localizations_root_path / Path(tile_id)
+        if not tile_path.exists():
+            raise FileNotFoundError(f"Directory {tile_path} does not exist.")
         return sorted([p.stem for p in tile_path.glob("*.parquet")], key=lambda x: int(x.replace("bit", "")))
 
+
 datastore_path = root_path / Path(r"qi2labdatastore")
-# initialize the qi2labDataStore class
 datastore = qi2labDataStore(datastore_path)
+smfish_class = smFISH_spotdetection(datastore)
 
-
-# Use the methods to get tile_ids and bit_ids
-tile_ids = datastore.get_tile_ids()
+tile_ids = smfish_class.get_tile_ids()
 for tile_id in tile_ids:
-    bit_ids = datastore.get_bit_ids(tile_id)
-    for tile_id, bit_id in product([tile_id], bit_ids):
-        ufish_localizations_df = datastore.read_ufish_localizations(tile_id, bit_id)
+    bit_ids = smfish_class.get_bit_ids(tile_id)
+    for bit_id in bit_ids:
+        ufish_localizations_df = smfish_class.read_ufish_localizations(tile_id, bit_id)
 
-        # Set the threshold for the ufish probabilities
-        threshold = 5
-
-        # grab the ufish localizations
         ufish_probabilities = ufish_localizations_df.loc[:, "sum_prob_pixels"]
-        # set everything <5 = 0
-        thresholded_probabilities = []
-        for prob in ufish_probabilities:
-            if prob < int(threshold):
-                thresholded_probabilities.append(0)
-            else:
-                thresholded_probabilities.append(prob)
+        ufish_localizations_df["thresholded_probabilities"] = ufish_probabilities.where(ufish_probabilities >= smfish_class.threshold, 0)
 
-        # Create a new column with thresholded values
-        ufish_localizations_df["thresholded_probabilities"] = thresholded_probabilities
-
-        # Save the updated DataFrame back to a new Parquet file
         output_path = datastore_path / "ufish_localizations_thresholded" / tile_id / f"{bit_id}_thresholded.parquet"
-        output_path.parent.mkdir(parents=True, exist_ok=True)  # Create directories if they don't exist
+        output_path.parent.mkdir(parents=True, exist_ok=True)
         ufish_localizations_df.to_parquet(output_path)
 
-print(f"Thresholded probabilities saved to {output_path}")
+print("Thresholded probabilities saved")

--- a/examples/bioprotean_smFISH/smFISH_spot_detection.py
+++ b/examples/bioprotean_smFISH/smFISH_spot_detection.py
@@ -2,6 +2,7 @@ from merfish3danalysis.qi2labDataStore import qi2labDataStore
 from pathlib import Path
 from typing import Union, Optional, Sequence, Collection
 import pandas as pd
+from itertools import product
 
 root_path = Path(r"/data/smFISH/02202025_Bartelle_control_smFISH_TqIB")
 
@@ -23,52 +24,47 @@ class qi2labDataStore:
         #     print("U-FISH localizations not found.")
         #  print(f"Attempting to read file: {current_ufish_localizations_path}")
         return pd.read_parquet(current_ufish_localizations_path)
+    
+    def get_tile_ids(self):
+        # Retrieve tile IDs from the directory structure
+        return sorted([p.name for p in self._ufish_localizations_root_path.iterdir() if p.is_dir()], key=lambda x: int(x.replace("tile", "")))
+
+    def get_bit_ids(self, tile_id):
+        # Retrieve bit IDs from the directory structure of a specific tile
+        tile_path = self._ufish_localizations_root_path / Path(tile_id)
+        return sorted([p.stem for p in tile_path.glob("*.parquet")], key=lambda x: int(x.replace("bit", "")))
 
 datastore_path = root_path / Path(r"qi2labdatastore")
 # initialize the qi2labDataStore class
 datastore = qi2labDataStore(datastore_path)
 
-# Read the ufish localizations from the Parquet file
-ufish_localizations_df = datastore.read_ufish_localizations("tile0000", "bit001")
-# print(ufish_localizations_df)
 
-# Output:
-#        z     y     x  sum_prob_pixels  sum_decon_pixels  tile_idx  bit_idx  tile_z_px  tile_y_px  tile_x_px
-# 0      0     9  1138        33.477734              6646         0        1          0          9       1138
-# 1      0   236   563        17.889059             23476         0        1          0        236        563
-# 2      0   295   123        43.437790             11803         0        1          0        295        123
-# 3      0   355   307        41.473850            398292         0        1          0        355        307
-# 4      0   362  1336        58.301956            355961         0        1          0        362       1336
-# ...   ..   ...   ...              ...               ...       ...      ...        ...        ...        ...
-# 9009  49  1942  1100        19.608427              2911         0        1         49       1942       1100
-# 9010  49  1986  1986        20.223333              2028         0        1         49       1986       1986
-# 9011  49  1999    74        21.493113              2139         0        1         49       1999         74
-# 9012  49  2014    86        15.593759              1597         0        1         49       2014         86
-# 9013  49  2018  1375        25.273598              5003         0        1         49       2018       1375
+# Use the methods to get tile_ids and bit_ids
+tile_ids = datastore.get_tile_ids()
+for tile_id in tile_ids:
+    bit_ids = datastore.get_bit_ids(tile_id)
+    for tile_id, bit_id in product([tile_id], bit_ids):
+        ufish_localizations_df = datastore.read_ufish_localizations(tile_id, bit_id)
 
-# [9014 rows x 10 columns]
+        # Set the threshold for the ufish probabilities
+        threshold = 5
 
+        # grab the ufish localizations
+        ufish_probabilities = ufish_localizations_df.loc[:, "sum_prob_pixels"]
+        # set everything <5 = 0
+        thresholded_probabilities = []
+        for prob in ufish_probabilities:
+            if prob < int(threshold):
+                thresholded_probabilities.append(0)
+            else:
+                thresholded_probabilities.append(prob)
 
-# Set the threshold for the ufish probabilities
-# threshold = 5
+        # Create a new column with thresholded values
+        ufish_localizations_df["thresholded_probabilities"] = thresholded_probabilities
 
-# grab the ufish localizations
-ufish_probabilities = ufish_localizations_df.loc[:, "sum_prob_pixels"]
-# set everything <5 = 0
-thresholded_probabilities = []
-for prob in ufish_probabilities:
-    if prob < 5:
-        thresholded_probabilities.append(0)
-    else:
-        thresholded_probabilities.append(prob)
-# print(thresholded_probabilities)
-# Create a new column with thresholded values
-ufish_localizations_df["thresholded_probabilities"] = thresholded_probabilities
-
-
-# Save the updated DataFrame back to a new Parquet file
-output_path = datastore_path / "ufish_localizations_thresholded" / "tile0000" / "bit001_thresholded.parquet"
-output_path.parent.mkdir(parents=True, exist_ok=True)  # Create directories if they don't exist
-ufish_localizations_df.to_parquet(output_path)
+        # Save the updated DataFrame back to a new Parquet file
+        output_path = datastore_path / "ufish_localizations_thresholded" / tile_id / f"{bit_id}_thresholded.parquet"
+        output_path.parent.mkdir(parents=True, exist_ok=True)  # Create directories if they don't exist
+        ufish_localizations_df.to_parquet(output_path)
 
 print(f"Thresholded probabilities saved to {output_path}")

--- a/examples/bioprotean_smFISH/smFISH_spot_detection.py
+++ b/examples/bioprotean_smFISH/smFISH_spot_detection.py
@@ -25,11 +25,10 @@ class qi2labDataStore:
         return pd.read_parquet(current_ufish_localizations_path)
 
 datastore_path = root_path / Path(r"qi2labdatastore")
+# initialize the qi2labDataStore class
 datastore = qi2labDataStore(datastore_path)
-# The __init__ method is automatically called when you create an instance of a class, as in the above line.
-# You do not need to call it explicitly
 
-# you need to call a method of the class or it will not be executed
+# Read the ufish localizations from the Parquet file
 ufish_localizations_df = datastore.read_ufish_localizations("tile0000", "bit001")
 # print(ufish_localizations_df)
 

--- a/src/merfish3danalysis/PixelDecoder.py
+++ b/src/merfish3danalysis/PixelDecoder.py
@@ -71,6 +71,7 @@ class PixelDecoder:
         use_mask: Optional[bool] = False,
         z_range: Optional[Sequence[int]] = None,
         include_blanks: Optional[bool] = True,
+        smFISH: bool = False
     ):
         self._datastore = datastore
         self._verbose = verbose
@@ -78,6 +79,10 @@ class PixelDecoder:
         self._include_blanks = include_blanks
 
         self._n_merfish_bits = merfish_bits
+
+        # Is this data smFISH or MERFISH? 
+        # Default is False, meaning data is MERFISH
+        self._smFISH = smFISH
 
         if self._datastore.microscope_type == "2D":
             self._is_3D = False
@@ -1841,12 +1846,20 @@ class PixelDecoder:
         app = QApplication.instance()
 
         app.lastWindowClosed.connect(on_close_callback)
-
-        viewer.add_image(
-            self._scaled_pixel_images,
-            scale=[self._axial_step, self._pixel_size, self._pixel_size],
-            name="pixels",
-        )
+        
+        if self._smFISH:
+            for bit in range(self._datastore.num_bits):
+                viewer.add_image(
+                    self._scaled_pixel_images[bit],
+                    scale=[self._axial_step, self._pixel_size, self._pixel_size],
+                    name="pixels_" + str(bit),
+                )
+        else:
+            viewer.add_image(
+                self._scaled_pixel_images,
+                scale=[self._axial_step, self._pixel_size, self._pixel_size],
+                name="pixels",
+            )
 
         viewer.add_image(
             self._decoded_image,

--- a/src/merfish3danalysis/PixelDecoder.py
+++ b/src/merfish3danalysis/PixelDecoder.py
@@ -956,8 +956,8 @@ class PixelDecoder:
         for barcode_index in iterable_barcode:
             on_bits_indices = np.where(self._codebook_matrix[barcode_index])[0]
 
-            if len(on_bits_indices) == 1:
-                break
+            # if len(on_bits_indices) == 1:
+            #     break
 
             if self._is_3D:
                 if self._verbose > 1:
@@ -999,10 +999,10 @@ class PixelDecoder:
 
                 df_barcode = pd.DataFrame(props)
 
-                df_barcode["on_bit_1"] = on_bits_indices[0] + 1
-                df_barcode["on_bit_2"] = on_bits_indices[1] + 1
-                df_barcode["on_bit_3"] = on_bits_indices[2] + 1
-                df_barcode["on_bit_4"] = on_bits_indices[3] + 1
+                df_barcode["on_bit_1"] = on_bits_indices[0] + 1 if len(on_bits_indices) > 0 else 0
+                df_barcode["on_bit_2"] = on_bits_indices[1] + 1 if len(on_bits_indices) > 1 else 0
+                df_barcode["on_bit_3"] = on_bits_indices[2] + 1 if len(on_bits_indices) > 2 else 0
+                df_barcode["on_bit_4"] = on_bits_indices[3] + 1 if len(on_bits_indices) > 3 else 0
                 df_barcode["barcode_id"] = df_barcode.apply(
                     lambda x: (barcode_index + 1), axis=1
                 )
@@ -1116,10 +1116,10 @@ class PixelDecoder:
 
                     df_barcode = pd.DataFrame(props)
 
-                    df_barcode["on_bit_1"] = on_bits_indices[0] + 1
-                    df_barcode["on_bit_2"] = on_bits_indices[1] + 1
-                    df_barcode["on_bit_3"] = on_bits_indices[2] + 1
-                    df_barcode["on_bit_4"] = on_bits_indices[3] + 1
+                    df_barcode["on_bit_1"] = on_bits_indices[0] + 1 if len(on_bits_indices) > 0 else 0
+                    df_barcode["on_bit_2"] = on_bits_indices[1] + 1 if len(on_bits_indices) > 1 else 0
+                    df_barcode["on_bit_3"] = on_bits_indices[2] + 1 if len(on_bits_indices) > 2 else 0
+                    df_barcode["on_bit_4"] = on_bits_indices[3] + 1 if len(on_bits_indices) > 3 else 0
                     df_barcode["barcode_id"] = df_barcode.apply(
                         lambda x: (barcode_index + 1), axis=1
                     )

--- a/src/merfish3danalysis/run_baysor.py
+++ b/src/merfish3danalysis/run_baysor.py
@@ -1,0 +1,11 @@
+
+
+
+#in pixeldecoder.py
+_reformat_barcodes_for_baysor
+
+# in qi2labdatastore.py
+
+_reformat_barcodes_for_baysor
+
+_run_baysor


### PR DESCRIPTION
The smFISH_spot_detection branch was created to adapt the pixel decoding for MERFISH for smFISH data. The decode_one_tile method in PixelDecoding opens multiple images in Napari - "pixels," "decoded," "magnitude," and "distance." The image in Napari labeled "pixels" represents the pre-decoding intensities of spots in 1 bit, whereas the "decoded" image that opens represents all bits, summarized using a grayscale gradient. (Black is zero, or bit 1. White is 15, or bit 16). T

I modified the display_results function in Pixel decoder to open up all 16 bits of pre-decoding spot intensities, so now you can toggle between the pre-decoded and decoded spots for all bits.