### PR TITLE
Display one tile of decoded smFISH results in Napari

### DIFF
--- a/examples/bioprotean_smFISH/smFISH_decoding.py
+++ b/examples/bioprotean_smFISH/smFISH_decoding.py
@@ -1,0 +1,34 @@
+from merfish3danalysis.qi2labDataStore import qi2labDataStore
+from merfish3danalysis.PixelDecoder import PixelDecoder
+from pathlib import Path
+# import numpy as np
+
+root_path = Path(r"/data/smFISH/02202025_Bartelle_control_smFISH_TqIB")
+
+# initialize datastore
+datastore_path = root_path / Path(r"qi2labdatastore")
+datastore = qi2labDataStore(datastore_path)
+merfish_bits = datastore.num_bits
+
+# initialize decodor class
+decoder = PixelDecoder(
+    datastore=datastore, 
+    use_mask=False, 
+    merfish_bits=merfish_bits, 
+    verbose=1,
+    smFISH = True
+)
+
+# decode one tile
+decoder.decode_one_tile(
+    tile_idx=0,  # Specify the tile index
+    display_results=True,  # Set to True to visualize results in Napari
+    lowpass_sigma=(3, 1, 1),  # Lowpass filter sigma
+    magnitude_threshold=0.9,  # L2-norm threshold
+    minimum_pixels=3.0,  # Minimum number of pixels for a barcode
+    use_normalization=False,  # Use normalization
+    ufish_threshold=0.5  # Ufish threshold
+)
+
+# # Save barcodes
+# decoder._save_barcodes()

--- a/src/merfish3danalysis/PixelDecoder.py
+++ b/src/merfish3danalysis/PixelDecoder.py
@@ -71,6 +71,7 @@ class PixelDecoder:
         use_mask: Optional[bool] = False,
         z_range: Optional[Sequence[int]] = None,
         include_blanks: Optional[bool] = True,
+        smFISH: bool = False
     ):
         self._datastore = datastore
         self._verbose = verbose
@@ -78,6 +79,10 @@ class PixelDecoder:
         self._include_blanks = include_blanks
 
         self._n_merfish_bits = merfish_bits
+
+        # Is this data smFISH or MERFISH? 
+        # Default is False, meaning data is MERFISH
+        self._smFISH = smFISH
 
         if self._datastore.microscope_type == "2D":
             self._is_3D = False
@@ -1841,12 +1846,20 @@ class PixelDecoder:
         app = QApplication.instance()
 
         app.lastWindowClosed.connect(on_close_callback)
-
-        viewer.add_image(
-            self._scaled_pixel_images,
-            scale=[self._axial_step, self._pixel_size, self._pixel_size],
-            name="pixels",
-        )
+        
+        if self._smFISH:
+            for bit in range(self._datastore.num_bits):
+                viewer.add_image(
+                    self._scaled_pixel_images[bit],
+                    scale=[self._axial_step, self._pixel_size, self._pixel_size],
+                    name="pixels_" + str(bit),
+                )
+        else:
+            viewer.add_image(
+                self._scaled_pixel_images,
+                scale=[self._axial_step, self._pixel_size, self._pixel_size],
+                name="pixels",
+            )
 
         viewer.add_image(
             self._decoded_image,


### PR DESCRIPTION
modified display_results method in PixelDecoder to display all bits in napari. 

Context:
The decode_one_tile method in PixelDecoding opens multiple images in Napari - "pixels," "decoded," "magnitude," and "distance." The image in Napari labeled "pixels" represents the pre-decoding intensities of spots in 1 bit, whereas the "decoded" image that opens represents all bits, summarized using a grayscale gradient. (Black is zero, or bit 1. White is 15, or bit 16). I modified the display_results function in Pixel decoder to open up all 16 bits of pre-decoding spot intensities, so now you can toggle between the pre-decoded and decoded spots for all bits. 