### PR TITLE
fix: store data z extent in metadata and use for psf z size/center

### DIFF
--- a/examples/statphysbio_synthetic/01_convert_simulation_to_experiment.py
+++ b/examples/statphysbio_synthetic/01_convert_simulation_to_experiment.py
@@ -105,6 +105,7 @@ def convert_simulation(
                         'num_t': int(1),
                         'num_r': int(num_rounds),
                         'num_xyz': int(1),
+                        'num_z' : int(num_z),
                         'num_ch': int(num_ch),
                         'na' : float(1.35),
                         'ri' : float(1.51),

--- a/examples/statphysbio_synthetic/02_convert_to_datastore.py
+++ b/examples/statphysbio_synthetic/02_convert_to_datastore.py
@@ -95,6 +95,7 @@ def convert_data(
     num_rounds = metadata["num_r"]
     num_tiles = metadata["num_xyz"]
     num_ch = metadata["num_ch"]
+    num_z  = metadata["num_z"]
 
     camera = "synthetic"
     e_per_ADU = metadata["gain"]
@@ -138,7 +139,7 @@ def convert_data(
     channel_psfs = []
     for channel_id in channels_in_data:
         psf = make_psf(
-            z=51,
+            z=num_z,
             nx=51,
             dxy=voxel_size_zyx_um[1],
             dz=voxel_size_zyx_um[0],


### PR DESCRIPTION
A small commit to the synthetic data example, to read the z extent of the data (planes per bit) and use that value to create the PSF and compute the PSF center.