### PR TITLE
fix: missing joblib dependency

### DIFF
--- a/src/merfish3danalysis/setup_merfish3d.py
+++ b/src/merfish3danalysis/setup_merfish3d.py
@@ -77,6 +77,7 @@ MVSTITCHER_ENV_PIP_IMPORTS = [
     "roifile",
     "shapely",
     "fastparquet",
+    "joblib",
 ]
 
 


### PR DESCRIPTION
Add `joblib` to dependency list for `multiview-stitcher` env.