### PR TITLE
fix: clean up more GPU memory during preprocess

### DIFF
--- a/src/merfish3danalysis/DataRegistration.py
+++ b/src/merfish3danalysis/DataRegistration.py
@@ -582,6 +582,10 @@ def _apply_bits_on_gpu(dr, bit_list: list, gpu_id: int = 0) -> bool:  # noqa: AN
             )
 
         if (not feature_predictor_on_disk) or dr._overwrite_registered:
+            clear_rlgc_caches(clear_memory_pool=True)
+            torch.cuda.empty_cache()
+            gc.collect()
+
             # UFISH
             ufish = UFish(device=f"cuda:{gpu_id}")
             _load_ufish_model(ufish, dr._ufish_model)

--- a/src/merfish3danalysis/DataRegistration.py
+++ b/src/merfish3danalysis/DataRegistration.py
@@ -586,10 +586,6 @@ def _apply_bits_on_gpu(dr, bit_list: list, gpu_id: int = 0) -> bool:  # noqa: AN
             )
 
         if (not feature_predictor_on_disk) or dr._overwrite_registered:
-            clear_rlgc_caches(clear_memory_pool=True)
-            torch.cuda.empty_cache()
-            gc.collect()
-
             # UFISH
             ufish = UFish(device=f"cuda:{gpu_id}")
             _load_ufish_model(ufish, dr._ufish_model)

--- a/src/merfish3danalysis/DataRegistration.py
+++ b/src/merfish3danalysis/DataRegistration.py
@@ -161,6 +161,7 @@ def _run_chunked_rlgc_remembering_crop(
     image: np.ndarray,
     psf: np.ndarray,
     gpu_id: int,
+    release_memory: bool = False,
 ) -> np.ndarray:
     """
     Run RLGC and remember the lateral chunk size that succeeds in this worker.
@@ -176,6 +177,8 @@ def _run_chunked_rlgc_remembering_crop(
     psf : np.ndarray
         Function argument.
     gpu_id : int
+        Function argument.
+    release_memory : bool
         Function argument.
 
     Returns
@@ -213,7 +216,7 @@ def _run_chunked_rlgc_remembering_crop(
         gpu_id=gpu_id,
         crop_yx=dr._crop_yx_decon,
         crop_z=None,
-        release_memory=False,
+        release_memory=release_memory,
         on_successful_crop_yx=_remember_successful_crop,
     )
 
@@ -521,6 +524,7 @@ def _apply_bits_on_gpu(dr, bit_list: list, gpu_id: int = 0) -> bool:  # noqa: AN
                     image=corrected_image,
                     psf=_resolve_psf(dr._psfs, psf_idx),
                     gpu_id=gpu_id,
+                    release_memory=True,
                 )
                 decon_image = decon_image.clip(0, 2**16 - 1).astype(np.uint16)
             else:

--- a/src/merfish3danalysis/utils/rlgc.py
+++ b/src/merfish3danalysis/utils/rlgc.py
@@ -57,11 +57,17 @@ def clear_rlgc_caches(clear_memory_pool: bool = False) -> None:
         cp.fft.config.get_plan_cache().clear()
     except Exception:
         pass
+    try:
+        import cupyx
+
+        cupyx.scipy.fft.clear_plan_cache()
+    except Exception:
+        pass
     if clear_memory_pool:
+        gc.collect()
         cp.cuda.Stream.null.synchronize()
         cp.get_default_memory_pool().free_all_blocks()
         cp.get_default_pinned_memory_pool().free_all_blocks()
-        gc.collect()
 
 
 def next_gpu_fft_size(x: int) -> int:


### PR DESCRIPTION
The new auto-chunk RLGC size feature allows for large GPU chunks, which can cause an OOM error when moving onto U-FISH. Fix is to release the FFT caches before transitioning to U-FISH.