### PR TITLE
ci: deploy documentation with GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,66 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pages: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@v9
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install documentation dependencies
+        run: uv sync --only-group docs
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build documentation
+        run: uv run --no-sync mkdocs build --clean --strict
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    name: Deploy documentation
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ To build the documentation, install using `uv sync --group docs`.
 Then execute `uv run mkdocs build --clean` or `uv run mkdocs serve`. The
 documentation is available in your web browser at `http://127.0.0.1:8000/`.
 
+Pushes to `main` automatically build and deploy the documentation through the
+`Documentation` GitHub Actions workflow. The workflow installs only the
+documentation dependency group and runs on a standard CPU runner; it does not
+require CUDA or GPU hardware. Configure the repository's Pages source as
+**GitHub Actions** under **Settings → Pages**.
+
 ## Testing
 
 The simulation tests require an NVIDIA GPU, the extracted sample data at

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,3 +31,9 @@ refinement.
 To build the documentation, install using `uv sync --group docs`.
 Then execute `uv run mkdocs build --clean` or `uv run mkdocs serve`. The
 documentation is available in your web browser at `http://127.0.0.1:8000/`.
+
+The `Documentation` GitHub Actions workflow builds and deploys the site after
+every push to `main` and can also be started manually. It uses only the `docs`
+dependency group on a standard CPU runner, so deployment does not require a
+CUDA-capable host. In the repository settings, set **Pages → Build and
+deployment → Source** to **GitHub Actions**.


### PR DESCRIPTION
## Summary

- add a GitHub Pages workflow triggered by pushes to `main` or manual dispatch
- install only the `docs` dependency group on a standard GitHub-hosted CPU runner
- build MkDocs in strict mode and deploy the generated artifact with the official Pages actions
- document the one-time GitHub Pages source setting

## Validation

- `git diff --cached --check`
- no Python, uv, MkDocs, tests, or GPU-dependent code was run locally, per the no-GPU-machine constraint

After merging, set **Settings → Pages → Build and deployment → Source** to **GitHub Actions** if it is not already selected.