### PR TITLE
fix: use allowed actions for docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,14 +26,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Set up uv and Python
-        uses: astral-sh/setup-uv@v9
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          enable-cache: true
+
+      - name: Install uv
+        run: python -m pip install "uv==0.12.5"
 
       - name: Install documentation dependencies
-        run: uv sync --only-group docs
+        run: uv sync --only-group docs --locked
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Cause

The organization action policy rejects `astral-sh/setup-uv`, so the documentation job stops before it can build the site.

## Fix

- replace `astral-sh/setup-uv@v9` with GitHub-owned `actions/setup-python@v6`
- install pinned `uv==0.12.5` from PyPI in a shell step
- retain the docs-only environment and add `--locked`
- keep every workflow action under the GitHub-owned `actions/*` namespace

## Validation

- static workflow and diff review
- confirmed every `uses:` entry in `.github/workflows/docs.yml` is GitHub-owned
- no local Python, uv, MkDocs, test, or GPU-dependent execution