### PR TITLE
fix: update mkdocstrings source path config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,12 +68,11 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
+          paths: [src]
           options:
             docstring_style: numpy
             filters: []
             summary: true
-          setup_commands:
-            - import sys; sys.path.insert(0, "src/")
   - minify:
       minify_html: true
   - mermaid2:


### PR DESCRIPTION
## Cause

The current `mkdocstrings-python` handler no longer accepts the legacy `setup_commands` setting, causing the documentation build to fail with:

`TypeError: PythonConfig.__init__() got an unexpected keyword argument 'setup_commands'`

## Fix

Replace the `sys.path` setup command with the supported and recommended handler configuration:

```yaml
paths: [src]
```

The Material for MkDocs message about a future MkDocs 2.0 is informational and is not the cause of this failure.

## Validation

- static configuration and diff review
- no local Python, uv, MkDocs, test, or GPU-dependent execution